### PR TITLE
removed mut attributes, fixed warnings while compiling

### DIFF
--- a/hoard/src/journal/mod.rs
+++ b/hoard/src/journal/mod.rs
@@ -235,7 +235,7 @@ impl<'a, 'p, 'v, H> save::AllocBlob for ItemAllocator<'a, 'v, 'p, H> {
     type Error = io::Error;
     type Done = WordOffset;
 
-    fn alloc_blob(mut self, size: usize) -> Result<Self::WriteBlob, Self::Error> {
+    fn alloc_blob(self, size: usize) -> Result<Self::WriteBlob, Self::Error> {
         Ok(self.0.write_item(size))
     }
 }

--- a/proofmarshal-collections/src/tree/marshal_impls.rs
+++ b/proofmarshal-collections/src/tree/marshal_impls.rs
@@ -159,7 +159,7 @@ where S: ValidateBlob,
 
     type Error = ValidateInnerBlobError<S::Error, P::Error>;
 
-    fn validate_blob<'a>(mut blob: BlobValidator<'a, Self>) -> Result<ValidBlob<'a, Self>, Self::Error> {
+    fn validate_blob<'a>(blob: BlobValidator<'a, Self>) -> Result<ValidBlob<'a, Self>, Self::Error> {
         /*
         blob.field::<SumTreeData<T, S, P>>().map_err(ValidateInnerBlobError::Left)?;
         blob.field::<SumTreeData<T, S, P>>().map_err(ValidateInnerBlobError::Right)?;


### PR DESCRIPTION
Hello Peter,

I had two errors today trying to compile with rust 1.45.0-nightly, I fixed quickly hope is ok.

➜  proofmarshal git:(master) cargo build
   Compiling owned v0.1.0
   Compiling singlelife v0.1.0 (/Users/gianluca/workspace/sparringparrots/proofmarshal/singlelife)
   Compiling leint v0.1.0 (/Users/gianluca/workspace/sparringparrots/proofmarshal/leint)
   Compiling fake-simd v0.1.2
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> singlelife/src/lib.rs:1:1
  |
1 | #![feature(arbitrary_self_types)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

   Compiling opaque-debug v0.2.3
   Compiling static_assertions v1.1.0
error: aborting due to previous error

For more information about this error, try `rustc --explain E0554`.
   Compiling sliceinit v0.1.0 (/Users/gianluca/workspace/sparringparrots/proofmarshal/sliceinit)
error: could not compile `singlelife`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed